### PR TITLE
Napo 487 episode alt

### DIFF
--- a/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
+++ b/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
@@ -17,9 +17,9 @@
 
                 // Take the value of the title field and set the image title attribute
                 var img_title;
-                jQuery('document').ready(function() {
-                    jQuery('ul.jcarousel-view--episode-list--block-1').find('li').each(function(){
-                        jQuery(this).mouseover(function(){
+                $('document').ready(function() {
+                    $('ul.jcarousel-view--episode-list--block-1').find('li').each(function(){
+                        $(this).mouseover(function(){
                             img_title = '';
                             $(this).find('div.views-field-title-field div.field-content a.napo_film_episode_link').each(function(){
                                 img_title = $(this).html().replace('</span>', ': ');

--- a/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
+++ b/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
@@ -14,6 +14,26 @@
             $('.modal').on('shown.bs.modal', function() {
                 $(window).trigger('resize');
                 $('.view-id-episode_list.view-display-id-block_1').show();
+
+                // Take the value of the title field and set the image title attribute
+                var img_title;
+                jQuery('document').ready(function() {
+                    jQuery('ul.jcarousel-view--episode-list--block-1').find('li').each(function(){
+                        jQuery(this).mouseover(function(){
+                            img_title = '';
+                            $(this).find('div.views-field-title-field div.field-content a.napo_film_episode_link').each(function(){
+                                img_title = $(this).html().replace('</span>', ': ');
+                                img_title = img_title.replace( /<.*?>/g, '' );
+                            });
+                            if(img_title){
+                                $(this).find('div.views-field-nothing span.field-content a.napo_film_episode_link img').each(function(){
+                                    $(this).attr('title', img_title);
+                                });
+                                $(this).find('div.views-field-title-field').remove();
+                            }
+                        })
+                    })
+                })
             });
             $('.modal').on('show.bs.modal', function() {
                 $('.view-id-episode_list.view-display-id-block_1').hide();

--- a/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
+++ b/docroot/sites/all/modules/napo/napo_film/js/napo_film.js
@@ -17,21 +17,19 @@
 
                 // Take the value of the title field and set the image title attribute
                 var img_title;
-                $('document').ready(function() {
-                    $('ul.jcarousel-view--episode-list--block-1').find('li').each(function(){
-                        $(this).mouseover(function(){
-                            img_title = '';
-                            $(this).find('div.views-field-title-field div.field-content a.napo_film_episode_link').each(function(){
-                                img_title = $(this).html().replace('</span>', ': ');
-                                img_title = img_title.replace( /<.*?>/g, '' );
+                $('ul.jcarousel-view--episode-list--block-1').find('li').each(function(){
+                    $(this).mouseover(function(){
+                        img_title = '';
+                        $(this).find('div.views-field-title-field div.field-content a.napo_film_episode_link').each(function(){
+                            img_title = $(this).html().replace('</span>', ': ');
+                            img_title = img_title.replace( /<.*?>/g, '' );
+                        });
+                        if(img_title){
+                            $(this).find('div.views-field-nothing span.field-content a.napo_film_episode_link img').each(function(){
+                                $(this).attr('title', img_title);
                             });
-                            if(img_title){
-                                $(this).find('div.views-field-nothing span.field-content a.napo_film_episode_link img').each(function(){
-                                    $(this).attr('title', img_title);
-                                });
-                                $(this).find('div.views-field-title-field').remove();
-                            }
-                        })
+                            $(this).find('div.views-field-title-field').remove();
+                        }
                     })
                 })
             });


### PR DESCRIPTION
The image title attribute is set - on the popup window - but there is a CSS class in style.css that will make image invisible and also the title attribute:

.modal .jcarousel-item:hover .views-field.views-field-nothing img {
  visibility: hidden;
}

In order to solve the issue, please delete the CSS class or try to modify it.